### PR TITLE
Add server path to information in notice

### DIFF
--- a/companion.php
+++ b/companion.php
@@ -30,11 +30,12 @@ function companion_admin_notices() {
 		<h3><?php echo esc_html__( 'Welcome to Jurassic Ninja!' ); ?></h3>
 		<p><strong><span id="jurassic_url"><?php echo esc_html( network_site_url() ); ?></span></strong> <?php echo esc_html__( 'will be destroyed 7 days after the last time anybody logged in.' ); ?></p>
 		<p>
-			<strong>Username:</strong> <code><span id="jurassic_username">demo</span></code>
-			<strong>SSH user </strong> <code><?php echo esc_html( $sysuser ); ?></code>
+			<strong>WP user:</strong> <code><span id="jurassic_username">demo</span></code>
+			<strong>SSH user:</strong> <code><span id="jurassic_ssh_user"><?php echo esc_html( $sysuser ); ?></span></code>
 		</p>
 		<p>
-			<strong>Password:</strong> <code><span id="jurassic_password"><?php echo esc_html( $admin_password ); ?></span></code>
+			<strong>WP/SSH password:</strong> <code><span id="jurassic_password"><?php echo esc_html( $admin_password ); ?></span></code>
+			<strong>SSH server path:</strong> <code><span id="jurassic_ssh_server_path"><?php echo esc_html( get_home_path() ); ?></span></code>
 		</p>
 	</div>
 	<?php


### PR DESCRIPTION
This PR adds the SSH server path to the information provided for user and also rearranges and rewords some labels:

<img width="727" alt="captura de pantalla 2018-02-23 a la s 11 49 59" src="https://user-images.githubusercontent.com/1041600/36600579-7068e8d2-1891-11e8-8241-663ca0b4e55b.png">
