### PR TITLE
Updates in jetpack constants page

### DIFF
--- a/companion.php
+++ b/companion.php
@@ -329,7 +329,4 @@ function companion_tamper_with_jetpack_constants() {
 	if ( ! ( defined( 'JETPACK_DEV_DEBUG' ) && JETPACK_DEV_DEBUG ) && companion_get_option( 'jetpack_dev_debug', '' ) ) {
 		define( 'JETPACK_DEV_DEBUG', companion_get_option( 'jetpack_dev_debug', '' ) ? true : false );
 	}
-	if ( ! ( defined( 'JETPACK_NO_USER_TEST_MODE' ) && JETPACK_NO_USER_TEST_MODE ) && companion_get_option( 'jetpack_no_user_testing', '' ) ) {
-		define( 'JETPACK_NO_USER_TEST_MODE', companion_get_option( 'jetpack_no_user_testing', '' ) ? true : false );
-	}
 }


### PR DESCRIPTION
Now that we have stand-alone plugins, it's useful to sandbox our Jetpack connection even when Jetpack-the-plugin is not present. See p9dueE-3Ap-p2

This PR enables the Jetpack Constants page and the sandbox configuration when Jetpack is not present.

It also:

* removes the `JETPACK_NO_USER_TEST_MODE` constant, as it is no longer useful.
* Adds a small comment to the `JETPACK_SHOULD_NOT_USE_CONNECTION_IFRAME` constant, as it is only useful in older Jetpack versions
* removes a unused deprecated variable

Testing:

* Set up a site with Jetpack Beta
* Deactivate Jetpack
* Make sure Jetpack Constants is still there and you can set the sandbox domain
* Make sure it works with other Jetpack-family plugins
* Make sure all options appear again when Jetpack-the-plugin is active