### PR TITLE
Add option check for disabling companion notice on non-dashboard pages

### DIFF
--- a/companion.php
+++ b/companion.php
@@ -134,6 +134,13 @@ function companion_admin_notices() {
 		if ( $screen->id === 'post' ) {
 			return;
 		}
+
+		// Option to show only on dashboard
+		if ( get_option( 'jurassic_ninja_companion_notice_on_dashboard', false ) ) {
+			if ( $screen->id !== 'dashboard' ) {
+				return;
+			}
+		}
 	}
 	$password_option_key = 'jurassic_ninja_admin_password';
 	$sysuser_option_key = 'jurassic_ninja_sysuser';


### PR DESCRIPTION
Plugin: [companion.zip](https://github.com/user-attachments/files/18700787/companion.zip)

### Testing instructions

1. Testing needs to be done together with 155629-ghe-Automattic/wpcom-a8c-themes