### PR TITLE
Add jurassic_ninja_experience option for post-login redirect

### DIFF
--- a/companion.php
+++ b/companion.php
@@ -320,11 +320,30 @@ function companion_wp_login() {
 			],
 		] );
 		if ( ! empty ( $auto_login ) ) {
-		    if ( empty( get_option( 'big_sky_api_key' ) ) ) {
-			    wp_safe_redirect( '/wp-admin' );
-		    } else {
-			    wp_safe_redirect( '/wp-admin/site-editor.php' );
-		    }
+			// Map of known Jurassic Ninja "experiences" to their landing URL.
+			// Closed list by design — to add an experience, edit this array.
+			$jn_experience_map = array(
+				'big-sky'      => '/wp-admin/site-editor.php',
+				'site-foundry' => '/wp-admin/network/admin.php?page=site-foundry',
+			);
+
+			$jn_experience = get_option( 'jurassic_ninja_experience' );
+
+			if ( ! empty( $jn_experience ) ) {
+				// Known slug → mapped URL. Unknown slug → fall through to /wp-admin.
+				$redirect_to = isset( $jn_experience_map[ $jn_experience ] )
+					? $jn_experience_map[ $jn_experience ]
+					: '/wp-admin';
+			} elseif ( ! empty( get_option( 'big_sky_api_key' ) ) ) {
+				// Transitional fallback: sites provisioned before `jurassic_ninja_experience`
+				// existed relied on `big_sky_api_key` to land in the site editor. Keep this
+				// so those sites continue to behave as they do today.
+				$redirect_to = '/wp-admin/site-editor.php';
+			} else {
+				$redirect_to = '/wp-admin';
+			}
+
+			wp_safe_redirect( $redirect_to );
 			exit( 0 );
 		}
 	} else {


### PR DESCRIPTION
## Summary

Adds a new `jurassic_ninja_experience` option (string slug) that selects the post-login landing URL on the Atomic path. The slug→URL map is a closed PHP array inside `companion.php` — no filter, no extensibility hook, deliberately a reviewable list.

### Experience map

| Slug | Landing URL |
|---|---|
| `big-sky` | `/wp-admin/site-editor.php` |
| `site-foundry` | `/wp-admin/network/admin.php?page=site-foundry` |

### Precedence on the Atomic auto-login path

1. `jurassic_ninja_experience` is set **and** matches a known slug → use the mapped URL.
2. `jurassic_ninja_experience` is set **but unknown** → `/wp-admin` (no error, no clever fallback to `big_sky_api_key`).
3. `jurassic_ninja_experience` not set, **and** `big_sky_api_key` is set → `/wp-admin/site-editor.php`. This is the existing Big Sky behaviour, kept as a transitional fallback so sites provisioned before this option existed continue to land where they do today.
4. Otherwise → `/wp-admin` (existing default).

The non-Atomic branch of `companion_wp_login()` is unchanged. The existing read-and-clear pattern for `auto_login` is preserved; `jurassic_ninja_experience` is read without clearing — it should persist for the life of the site.

### Rollout

The JN side will start setting `jurassic_ninja_experience` in a follow-up. **Until the JN side ships, no live site sets this option, so this change is a no-op for existing traffic** — the only behaviour change is that future JN sites with the option set will redirect to the mapped URL.

## Test plan

- [ ] On an Atomic JN site with `jurassic_ninja_experience=big-sky` and `auto_login=1`, login redirects to `/wp-admin/site-editor.php`.
- [ ] On an Atomic JN site with `jurassic_ninja_experience=site-foundry` and `auto_login=1`, login redirects to `/wp-admin/network/admin.php?page=site-foundry`.
- [ ] On an Atomic JN site with `jurassic_ninja_experience=garbage-slug` and `auto_login=1`, login redirects to `/wp-admin` (does NOT fall through to `big_sky_api_key`).
- [ ] On an Atomic JN site with no `jurassic_ninja_experience` and `big_sky_api_key` set, login still redirects to `/wp-admin/site-editor.php` (legacy fallback intact).
- [ ] On an Atomic JN site with neither option set, login redirects to `/wp-admin`.
- [ ] Non-Atomic path still redirects to `/wp-admin` after the checkin POST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)