### PR TITLE
Fix feature flag saves being dropped when the Jetpack package is absent

### DIFF
--- a/class-companion-feature-flag-command.php
+++ b/class-companion-feature-flag-command.php
@@ -18,6 +18,8 @@ class Companion_Feature_Flag_Command {
 	private $flags;
 
 	/**
+	 * Binds the commands to the settings instance they operate on.
+	 *
 	 * @param Companion_Feature_Flags $flags Instance to operate on.
 	 */
 	public function __construct( Companion_Feature_Flags $flags ) {
@@ -75,12 +77,26 @@ class Companion_Feature_Flag_Command {
 	 * @return void
 	 */
 	public function list_( $args, $assoc_args ) {
-		$flags     = Companion_Feature_Flags::get_registered_flags();
-		$overrides = $this->flags->get_overrides();
+		$flags       = Companion_Feature_Flags::get_registered_flags();
+		$overrides   = $this->flags->get_overrides();
+		$has_package = Companion_Feature_Flags::has_package();
 
-		if ( ! Companion_Feature_Flags::has_package() ) {
+		if ( ! $has_package ) {
 			WP_CLI::warning( 'The Jetpack feature flags package is not loaded on this site, so no flags can be discovered.' );
 		}
+
+		/*
+		 * Without the package there is nothing to resolve a flag against, and is_enabled()
+		 * returns a hard false. Printing that as "off" next to an override of "on" reads as a
+		 * resolved state rather than an unknowable one, so report it as unknown instead.
+		 */
+		$effective = function ( $name ) use ( $has_package ) {
+			if ( ! $has_package ) {
+				return '-';
+			}
+
+			return Companion_Feature_Flags::is_enabled( $name ) ? 'on' : 'off';
+		};
 
 		$rows = array();
 
@@ -89,7 +105,7 @@ class Companion_Feature_Flag_Command {
 				'flag'        => $name,
 				'default'     => $definition['default'] ? 'on' : 'off',
 				'override'    => array_key_exists( $name, $overrides ) ? ( $overrides[ $name ] ? 'on' : 'off' ) : '-',
-				'effective'   => Companion_Feature_Flags::is_enabled( $name ) ? 'on' : 'off',
+				'effective'   => $effective( $name ),
 				'owner'       => '' === $definition['owner'] ? '-' : $definition['owner'],
 				'description' => '' === $definition['description'] ? '-' : $definition['description'],
 			);
@@ -101,7 +117,7 @@ class Companion_Feature_Flag_Command {
 				'flag'        => $name,
 				'default'     => '-',
 				'override'    => $enabled ? 'on' : 'off',
-				'effective'   => Companion_Feature_Flags::is_enabled( $name ) ? 'on' : 'off',
+				'effective'   => $effective( $name ),
 				'owner'       => '-',
 				'description' => 'Not registered on this site.',
 			);
@@ -170,10 +186,14 @@ class Companion_Feature_Flag_Command {
 	 * [--all]
 	 * : Clear every stored override.
 	 *
+	 * [--yes]
+	 * : Skip the confirmation prompt when clearing every override.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *     wp companion feature-flag reset newsletter-new-subscribe-form
 	 *     wp companion feature-flag reset --all
+	 *     wp companion feature-flag reset --all --yes
 	 *
 	 * @param array $args       Positional arguments.
 	 * @param array $assoc_args Associative arguments.
@@ -189,6 +209,10 @@ class Companion_Feature_Flag_Command {
 			}
 
 			$count = count( $this->flags->get_overrides() );
+
+			// Auto-passes when --yes is supplied, so scripted callers are unaffected.
+			WP_CLI::confirm( sprintf( 'Clear %d feature flag override(s)?', $count ), $assoc_args );
+
 			$this->flags->update_overrides( array() );
 			WP_CLI::success( sprintf( 'Cleared %d feature flag override(s).', $count ) );
 
@@ -209,7 +233,12 @@ class Companion_Feature_Flag_Command {
 		}
 
 		unset( $overrides[ $name ] );
-		$this->flags->update_overrides( $overrides );
+		$stored = $this->flags->update_overrides( $overrides );
+
+		// Same reasoning as set_override(): report what was stored, not what was asked for.
+		if ( array_key_exists( $name, $stored ) ) {
+			WP_CLI::error( sprintf( 'Could not clear the override for "%s".', $name ) );
+		}
 
 		WP_CLI::success( sprintf( '%s now follows its registered default.', $name ) );
 	}

--- a/class-companion-feature-flags.php
+++ b/class-companion-feature-flags.php
@@ -89,6 +89,8 @@ class Companion_Feature_Flags {
 	private $section_title;
 
 	/**
+	 * Configures the option, settings group, page, and section this instance uses.
+	 *
 	 * @param array $args {
 	 *     Optional. Configuration overrides.
 	 *
@@ -235,11 +237,13 @@ class Companion_Feature_Flags {
 	 * @return array<string, array> Flag definitions keyed by name.
 	 */
 	public static function get_registered_flags() {
-		if ( ! self::has_package() ) {
+		if ( ! self::has_method( 'all' ) ) {
 			return array();
 		}
 
-		return call_user_func( array( self::PACKAGE_CLASS, 'all' ) );
+		$flags = call_user_func( array( self::PACKAGE_CLASS, 'all' ) );
+
+		return is_array( $flags ) ? $flags : array();
 	}
 
 	/**
@@ -249,6 +253,21 @@ class Companion_Feature_Flags {
 	 */
 	public static function has_package() {
 		return class_exists( self::PACKAGE_CLASS );
+	}
+
+	/**
+	 * Whether the package exposes a given static method.
+	 *
+	 * The package is a 0.x release and nothing here pins a version, so the method is checked
+	 * rather than just the class. Without this a rename upstream would fatal mid-render
+	 * instead of degrading to the same empty state a missing package already produces.
+	 *
+	 * @param string $method Method name.
+	 *
+	 * @return bool
+	 */
+	private static function has_method( $method ) {
+		return is_callable( array( self::PACKAGE_CLASS, $method ) );
 	}
 
 	/**
@@ -301,7 +320,7 @@ class Companion_Feature_Flags {
 	 * @return bool
 	 */
 	public static function is_enabled( $name ) {
-		if ( ! self::has_package() ) {
+		if ( ! self::has_method( 'is_enabled' ) ) {
 			return false;
 		}
 
@@ -319,13 +338,18 @@ class Companion_Feature_Flags {
 	 * registers after any sections the page builds itself and therefore renders last, and
 	 * registers the option into the page's own settings group so its Save button persists it.
 	 *
+	 * The option registers whether or not the package is present; only the section is gated.
+	 * register_setting() is what puts the option on the settings group's allowed list and
+	 * installs the sanitize callback, so gating it means options.php silently discards a
+	 * posted value while still reporting "Settings saved" — and programmatic writes during an
+	 * admin request skip sanitizing. That matters beyond the narrow case of Jetpack being
+	 * deactivated between render and save: no plugin currently ships the feature flags
+	 * package, so package-absent is the normal state rather than an edge case. There is
+	 * nothing to render without the package, hence the guard staying on the section alone.
+	 *
 	 * @return void
 	 */
 	public function register_section() {
-		if ( ! self::has_package() ) {
-			return;
-		}
-
 		register_setting(
 			$this->settings_group,
 			$this->option,
@@ -333,6 +357,10 @@ class Companion_Feature_Flags {
 				'sanitize_callback' => array( $this, 'sanitize' ),
 			)
 		);
+
+		if ( ! self::has_package() ) {
+			return;
+		}
 
 		add_settings_section(
 			$this->section_id,
@@ -492,6 +520,7 @@ class Companion_Feature_Flags {
 					echo esc_html( $definition['description'] );
 				}
 				if ( $is_registered && '' !== $definition['owner'] ) {
+					// translators: %s is the owning package, plugin, or product area for the flag.
 					echo ' <em>' . esc_html( sprintf( __( 'Owner: %s', 'companion' ), $definition['owner'] ) ) . '</em>';
 				}
 				?>


### PR DESCRIPTION
Follow-ups from reviewing PR 88 after it merged. Two of these are behavior bugs; the rest are cheap robustness and conformance.

Context worth stating up front, because it changes how the first item reads: nothing ships the package yet. No `composer.json` in the Jetpack monorepo requires `automattic/jetpack-feature-flags`, and `Feature_Flags::register()` is only called from the package's own tests and the PHPCS sniff that validates it. On a jetpack-dev trunk build, `class_exists( 'Automattic\Jetpack\Feature_Flags\Feature_Flags' )` is false. So package-absent isn't an edge case — it's every site today.

## Saves were silently dropped without the package

`register_setting()` sat behind the `has_package()` guard. That call is what puts the option on the settings group's allowed list and installs the `sanitize_option_{$option}` callback, so without it `options.php` quietly ignores the posted value and still reports "Settings saved."

Reproduced on a JN site with the package absent, baseline `{"shiny-on-by-default":true}`, posting `shiny-on-by-default=off`:

```
before:  {"shiny-on-by-default":true}     # unchanged, no error surfaced
after:   {"shiny-on-by-default":false}
```

Only the section is gated now. There's nothing to render without the package, but the option should still sanitize and store. This also covers the narrower case of Jetpack being deactivated between the page render and the save.

## `effective` reported a resolved state it couldn't know

```
flag                 default  override  effective  owner  description
shiny-on-by-default  -        on        off        -      Not registered on this site.
```

Override `on`, effective `off`, printed right under the command's own "package is not loaded" warning. `is_enabled()` returns a hard `false` in that state, which isn't the same as a genuine off. Reads `-` now.

## Robustness and conformance

- **Check the method, not just the class.** `get_registered_flags()` and `is_enabled()` checked `class_exists` then called through `call_user_func`. The package is a 0.x release with nothing pinning it here, so an upstream rename fatalled inside `render_section()` instead of degrading. Now guarded with `is_callable`, with a non-array `all()` result coerced.
- **`reset --all` confirms.** One mistyped command cleared everything. `--yes` is declared in the synopsis, without which WP-CLI rejects the flag as an unknown parameter.
- **`reset()` checks what was stored**, matching what `set_override()` already does.
- **Missing `translators:` comment** on the `Owner: %s` placeholder, plus two constructor docblock summary lines.

## Testing

Verified on a Jurassic Ninja site with the branch installed over the mu-plugin Companion, plus a shim loading the real feature flags package source and registering two flags through its actual API. Exercised with the package both present and absent:

- Posting a flag change with the package missing now persists; previously unchanged
- `effective` reads `-` instead of `off` when the package is missing
- The section still stays hidden without the package, and still renders with it — no PHP notices either way
- `enable` / `disable` / `reset` / `reset --all` / `reset --all --yes` all behave, and the confirmation prompt appears without `--yes`
- Settings page saves still work end to end, and the `sanitize()` round trip is unchanged: every radio on `default` clears the option, and posting the group without the flags key preserves what's stored
